### PR TITLE
Adding a suggestion to change credentials file name to specify wifi

### DIFF
--- a/0TA_Template_Sketch/OTA.h
+++ b/0TA_Template_Sketch/OTA.h
@@ -2,7 +2,7 @@
 #include <ESPmDNS.h>
 #include <WiFiUdp.h>
 #include <ArduinoOTA.h>
-#include <credentials.h>
+#include <wifi_credentials.h>
 
 const char* ssid = mySSID;
 const char* password = myPASSWORD;

--- a/0TA_Template_Sketch/wifi_credentials.h
+++ b/0TA_Template_Sketch/wifi_credentials.h
@@ -1,0 +1,8 @@
+//
+// DO NOT UPLOAD YOUR REAL CREDS TO GITHUB!!
+//
+// Include in sketch simply with:
+// #include <wifi_credentials.h>
+#define mySSID "yourSSID"		// ssid of access point
+#define myPASSWORD "YourWifiPassword"	// password of access point
+


### PR DESCRIPTION
First, thanks for these sketches, I will be playing with them as I want to replace my ESP8266's. I'd like to suggest a small change, change `credentials.h` to `wifi_credentials.h`, I do this as I tend to store say wifi credentials and maybe MQTT or ThinkSpeak API Keys under a separate file. For me, wifi will always be the same at home, but other creds would be different. 

Maybe it's just me that does this LOL just a suggestion.