### PR TITLE
Use MAC[3..5] as suffix for OTA hostname

### DIFF
--- a/0TA_Template_Sketch/0TA_Template_Sketch.ino
+++ b/0TA_Template_Sketch/0TA_Template_Sketch.ino
@@ -4,8 +4,7 @@ void setup() {
   Serial.begin(115200);
   Serial.println("Booting");
 
-  ArduinoOTA.setHostname("TemplateSketch");
-  setupOTA();
+  setupOTA("TemplateSketch");
 
   // your code
 

--- a/0TA_Template_Sketch/OTA.h
+++ b/0TA_Template_Sketch/OTA.h
@@ -7,7 +7,13 @@
 const char* ssid = mySSID;
 const char* password = myPASSWORD;
 
-void setupOTA() {
+void setupOTA(const char* nameprefix) {
+  const int maxlen = 40;
+  char fullhostname[maxlen];
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  snprintf(fullhostname, maxlen, "%s-%02x%02x%02x", nameprefix, mac[3], mac[4], mac[5]);
+  ArduinoOTA.setHostname(fullhostname);
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   while (WiFi.waitForConnectResult() != WL_CONNECTED) {

--- a/0TA_Template_Sketch_TelnetStream/0TA_Template_Sketch_TelnetStream.ino
+++ b/0TA_Template_Sketch_TelnetStream/0TA_Template_Sketch_TelnetStream.ino
@@ -5,8 +5,10 @@ unsigned long entry;
 void setup() {
   Serial.begin(115200);
   Serial.println("Booting");
-  ArduinoOTA.setHostname("TemplateSketch");
-  setupOTA();
+  
+  setupOTA("TemplateSketch");
+
+  // your code here
   
 }
 
@@ -16,4 +18,7 @@ void loop() {
   TelnetStream.println(micros()-entry);
   TelnetStream.println("Loop");
   delay(1000);
+
+  // your code here
+
 }

--- a/0TA_Template_Sketch_TelnetStream/OTA.h
+++ b/0TA_Template_Sketch_TelnetStream/OTA.h
@@ -8,7 +8,13 @@
 const char* ssid = mySSID;
 const char* password = myPASSWORD;
 
-void setupOTA() {
+void setupOTA(const char* nameprefix) {
+  const int maxlen = 40;
+  char fullhostname[maxlen];
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  snprintf(fullhostname, maxlen, "%s-%02x%02x%02x", nameprefix, mac[3], mac[4], mac[5]);
+  ArduinoOTA.setHostname(fullhostname);
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   while (WiFi.waitForConnectResult() != WL_CONNECTED) {


### PR DESCRIPTION
API has changed a bit: instead of calling ArduinoOTA.setHostname() with your hostname first and setupOTA() afterwards you now simply call setupOTA() with your hostname. That function will use the supplied hostname and add the lower 3 bytes of the MAC address as a suffix. This helps distinguishing devices having the same hostname otherwise.