### PR TITLE
Fixes #8, and other improvements.

### DIFF
--- a/0TA_Template_Sketch/0TA_Template_Sketch.ino
+++ b/0TA_Template_Sketch/0TA_Template_Sketch.ino
@@ -1,25 +1,23 @@
-#include "OTA.h"
-unsigned long entry;
+#define ESP32_RTOS  // Uncomment this line if you want to use the code with freertos only on the ESP32
+                    // Has to be done before including "OTA.h"
 
-// #define ESP32_RTOS  // Uncomment this line if you want to use the code with freertos (only works on the ESP32)
+#include "OTA.h"
+#include <credentials.h>
 
 void setup() {
   Serial.begin(115200);
   Serial.println("Booting");
 
-  setupOTA("TemplateSketch");
+  setupOTA("TemplateSketch", mySSID, myPASSWORD);
 
-  // your code
-
+  // Your setup code
 }
 
 void loop() {
-#ifndef ESP32_RTOS
+#ifdef defined(ESP32_RTOS) && defined(ESP32)
+#else // If you do not use FreeRTOS, you have to regulary call the handle method.
   ArduinoOTA.handle();
 #endif
 
-  delay(20);
-
-  // your code here
-
+  // Your code here
 }

--- a/0TA_Template_Sketch/OTA.h
+++ b/0TA_Template_Sketch/OTA.h
@@ -6,32 +6,33 @@
 #include <ESP8266mDNS.h>
 #endif
 
-
 #include <WiFiUdp.h>
 #include <ArduinoOTA.h>
-#include <credentials.h>
-
-const char* ssid = mySSID;
-const char* password = myPASSWORD;
 
 #if defined(ESP32_RTOS) && defined(ESP32)
-void taskOne( void * parameter )
-{
-  ArduinoOTA.handle();
-  delay(3500);
+void ota_handle( void * parameter ) {
+  for (;;) {
+    ArduinoOTA.handle();
+    delay(3500);
+  }
 }
 #endif
 
-void setupOTA(const char* nameprefix) {
-  const int maxlen = 40;
-  char fullhostname[maxlen];
+void setupOTA(const char* nameprefix, const char* ssid, const char* password) {
+  // Configure the hostname
+  uint16_t maxlen = strlen(nameprefix) + 7;
+  char *fullhostname = new char[maxlen];
   uint8_t mac[6];
   WiFi.macAddress(mac);
   snprintf(fullhostname, maxlen, "%s-%02x%02x%02x", nameprefix, mac[3], mac[4], mac[5]);
   ArduinoOTA.setHostname(fullhostname);
-  
+  delete[] fullhostname;
+
+  // Configure and start the WiFi station
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
+
+  // Wait for connection
   while (WiFi.waitForConnectResult() != WL_CONNECTED) {
     Serial.println("Connection Failed! Rebooting...");
     delay(5000);
@@ -58,19 +59,22 @@ void setupOTA(const char* nameprefix) {
     // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
     Serial.println("Start updating " + type);
   });
+  
   ArduinoOTA.onEnd([]() {
     Serial.println("\nEnd");
   });
+  
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
     Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
   });
+  
   ArduinoOTA.onError([](ota_error_t error) {
     Serial.printf("Error[%u]: ", error);
-    if (error == OTA_AUTH_ERROR) Serial.println("Auth Failed");
-    else if (error == OTA_BEGIN_ERROR) Serial.println("Begin Failed");
-    else if (error == OTA_CONNECT_ERROR) Serial.println("Connect Failed");
-    else if (error == OTA_RECEIVE_ERROR) Serial.println("Receive Failed");
-    else if (error == OTA_END_ERROR) Serial.println("End Failed");
+    if (error == OTA_AUTH_ERROR) Serial.println("\nAuth Failed");
+    else if (error == OTA_BEGIN_ERROR) Serial.println("\nBegin Failed");
+    else if (error == OTA_CONNECT_ERROR) Serial.println("\nConnect Failed");
+    else if (error == OTA_RECEIVE_ERROR) Serial.println("\nReceive Failed");
+    else if (error == OTA_END_ERROR) Serial.println("\nEnd Failed");
   });
 
   ArduinoOTA.begin();

--- a/0TA_Template_Sketch/OTA.h
+++ b/0TA_Template_Sketch/OTA.h
@@ -40,7 +40,7 @@ void setupOTA(const char* nameprefix, const char* ssid, const char* password) {
   }
 
   // Port defaults to 3232
-  // ArduinoOTA.setPort(3232);
+  // ArduinoOTA.setPort(3232); // Use 8266 port if you are working in Sloeber IDE, it is fixed there and not adjustable
 
   // No authentication by default
   // ArduinoOTA.setPassword("admin");
@@ -50,6 +50,7 @@ void setupOTA(const char* nameprefix, const char* ssid, const char* password) {
   // ArduinoOTA.setPasswordHash("21232f297a57a5a743894a0e4a801fc3");
 
   ArduinoOTA.onStart([]() {
+	//NOTE: make .detach() here for all functions called by Ticker.h library - not to interrupt transfer process in any way.
     String type;
     if (ArduinoOTA.getCommand() == U_FLASH)
       type = "sketch";

--- a/0TA_Template_Sketch_TelnetStream/0TA_Template_Sketch_TelnetStream.ino
+++ b/0TA_Template_Sketch_TelnetStream/0TA_Template_Sketch_TelnetStream.ino
@@ -1,24 +1,28 @@
+#define ESP32_RTOS  // Uncomment this line if you want to use the code with freertos only on the ESP32
+                    // Has to be done before including "OTA.h"
+
 #include "OTA.h"
+#include <credentials.h>
 
-// #define ESP32_RTOS  // Uncomment this line if you want to use the code with freertos (only works on the ESP32)
-
-unsigned long entry;
+uint32_t entry;
 
 void setup() {
   Serial.begin(115200);
   Serial.println("Booting");
-  setupOTA("TemplateSketch");
-  
+
+  setupOTA("TemplateSketch", mySSID, myPASSWORD);
+
+  // Your setup code
 }
 
 void loop() {
-  entry=micros();
-  
-  #ifndef ESP32_RTOS
+  entry = micros();
+#ifdef defined(ESP32_RTOS) && defined(ESP32)
+#else // If you do not use FreeRTOS, you have to regulary call the handle method.
   ArduinoOTA.handle();
-  #endif
-  
+#endif
   TelnetStream.println(micros()-entry);
   TelnetStream.println("Loop");
   delay(1000);
+  // Your code here
 }

--- a/0TA_Template_Sketch_TelnetStream/OTA.h
+++ b/0TA_Template_Sketch_TelnetStream/OTA.h
@@ -41,7 +41,7 @@ void setupOTA(const char* nameprefix, const char* ssid, const char* password) {
   }
 
   // Port defaults to 3232
-  // ArduinoOTA.setPort(3232);
+  // ArduinoOTA.setPort(3232); // Use 8266 port if you are working in Sloeber IDE, it is fixed there and not adjustable
 
   // No authentication by default
   // ArduinoOTA.setPassword("admin");
@@ -51,6 +51,7 @@ void setupOTA(const char* nameprefix, const char* ssid, const char* password) {
   // ArduinoOTA.setPasswordHash("21232f297a57a5a743894a0e4a801fc3");
 
   ArduinoOTA.onStart([]() {
+	//NOTE: make .detach() here for all functions called by Ticker.h library - not to interrupt transfer process in any way.
     String type;
     if (ArduinoOTA.getCommand() == U_FLASH)
       type = "sketch";

--- a/0TA_Template_Sketch_TelnetStream/OTA.h
+++ b/0TA_Template_Sketch_TelnetStream/OTA.h
@@ -9,29 +9,31 @@
 #include <WiFiUdp.h>
 #include <ArduinoOTA.h>
 #include <TelnetStream.h>
-#include <credentials.h>
-
-const char* ssid = mySSID;
-const char* password = myPASSWORD;
 
 #if defined(ESP32_RTOS) && defined(ESP32)
-void taskOne( void * parameter )
-{
-  ArduinoOTA.handle();
-  delay(3500);
+void ota_handle( void * parameter ) {
+  for (;;) {
+    ArduinoOTA.handle();
+    delay(3500);
+  }
 }
 #endif
 
-void setupOTA(const char* nameprefix) {
-  const int maxlen = 40;
-  char fullhostname[maxlen];
+void setupOTA(const char* nameprefix, const char* ssid, const char* password) {
+  // Configure the hostname
+  uint16_t maxlen = strlen(nameprefix) + 7;
+  char *fullhostname = new char[maxlen];
   uint8_t mac[6];
   WiFi.macAddress(mac);
   snprintf(fullhostname, maxlen, "%s-%02x%02x%02x", nameprefix, mac[3], mac[4], mac[5]);
   ArduinoOTA.setHostname(fullhostname);
-  
+  delete[] fullhostname;
+
+  // Configure and start the WiFi station
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
+
+  // Wait for connection
   while (WiFi.waitForConnectResult() != WL_CONNECTED) {
     Serial.println("Connection Failed! Rebooting...");
     delay(5000);
@@ -48,7 +50,6 @@ void setupOTA(const char* nameprefix) {
   // MD5(admin) = 21232f297a57a5a743894a0e4a801fc3
   // ArduinoOTA.setPasswordHash("21232f297a57a5a743894a0e4a801fc3");
 
-  
   ArduinoOTA.onStart([]() {
     String type;
     if (ArduinoOTA.getCommand() == U_FLASH)
@@ -59,19 +60,22 @@ void setupOTA(const char* nameprefix) {
     // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
     Serial.println("Start updating " + type);
   });
+  
   ArduinoOTA.onEnd([]() {
     Serial.println("\nEnd");
   });
+  
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
     Serial.printf("Progress: %u%%\r", (progress / (total / 100)));
   });
+  
   ArduinoOTA.onError([](ota_error_t error) {
     Serial.printf("Error[%u]: ", error);
-    if (error == OTA_AUTH_ERROR) Serial.println("Auth Failed");
-    else if (error == OTA_BEGIN_ERROR) Serial.println("Begin Failed");
-    else if (error == OTA_CONNECT_ERROR) Serial.println("Connect Failed");
-    else if (error == OTA_RECEIVE_ERROR) Serial.println("Receive Failed");
-    else if (error == OTA_END_ERROR) Serial.println("End Failed");
+    if (error == OTA_AUTH_ERROR) Serial.println("\nAuth Failed");
+    else if (error == OTA_BEGIN_ERROR) Serial.println("\nBegin Failed");
+    else if (error == OTA_CONNECT_ERROR) Serial.println("\nConnect Failed");
+    else if (error == OTA_RECEIVE_ERROR) Serial.println("\nReceive Failed");
+    else if (error == OTA_END_ERROR) Serial.println("\nEnd Failed");
   });
 
   ArduinoOTA.begin();

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Material for my YouTube [video](https://www.youtube.com/watch?v=1pwqS_NUG7Q).
 
 ## Installation
 
-In order to use the code provided in this repository you need to provide the credentials of your access point. Or you can comment out the `#include <credentials.h>` and define the mySSID and myPASSWORD to the `setupOTA("TemplateSketch", mySSID, myPASSWORD)` function.
+In order to use the code provided in this repository you need to provide the credentials of your access point. Or you can comment out the `#include <credentials.h>` and define the ``mySSID`` and ``myPASSWORD`` to the `setupOTA("TemplateSketch", mySSID, myPASSWORD)` function.
 
 ### Provide your credentials
 
 Create a `credentials.h` file (in the sketch folder directly or in the Arduino library folder).
-For Windows , the library folder is located in the same folder as the  sketch (`[...]\Arduino\libraries\Credentials`, `[...]\Arduino`).
+For Windows, the library folder is located in the same folder as the  sketch (`[...]\Arduino\libraries\Credentials`, `[...]\Arduino`).
 
 The text file `credentials.h` looks like:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # ESP32 OTA
- 
-Material for my YouTube video
+
+Material for my YouTube [video](https://www.youtube.com/watch?v=1pwqS_NUG7Q).
+
+## Installation
+
+In order to use the code provided in this repository you need to provide the credentials of your access point. Or you can comment out the `#include <credentials.h>` and define the mySSID and myPASSWORD to the `setupOTA("TemplateSketch", mySSID, myPASSWORD)` function.
+
+### Provide your credentials
+
+Create a `credentials.h` file (in the sketch folder directly or in the Arduino library folder).
+For Windows , the library folder is located in the same folder as the  sketch (`[...]\Arduino\libraries\Credentials`, `[...]\Arduino`).
+
+The text file `credentials.h` looks like:
+
+```c++
+#pragma once
+const char* mySSID = "SSID of your AP";
+const char* myPASSWORD = "Password of your AP";
+```


### PR DESCRIPTION
As it appears in issue #8, there was some errors in the code, making the use of FreeRTOS ineffective.

Therefore the following changes/improvements have been implemented:

> - Improve README.md
> - Correct FreeRTOS task function name and code
> - Dynamically handle the parameters passed to the setupOTA function
> - Explicitly provide the credentials in the sketch
> /!\ the modification have been made on both sketch but have only been tested on the non Telnet code.