### PR TITLE
Fix define for ESP32_RTOS and RTOS task function

### DIFF
--- a/0TA_Template_Sketch/0TA_Template_Sketch.ino
+++ b/0TA_Template_Sketch/0TA_Template_Sketch.ino
@@ -1,7 +1,7 @@
 #include "OTA.h"
 unsigned long entry;
 
-// #define ESP32_RTOS  // Uncomment this line if you want to use the code with freertos (only works on the ESP32)
+// #define ESP32_RTOS 1  // Uncomment this line if you want to use the code with freertos (only works on the ESP32)
 
 void setup() {
   Serial.begin(115200);

--- a/0TA_Template_Sketch/OTA.h
+++ b/0TA_Template_Sketch/OTA.h
@@ -15,10 +15,12 @@ const char* ssid = mySSID;
 const char* password = myPASSWORD;
 
 #if defined(ESP32_RTOS) && defined(ESP32)
-void taskOne( void * parameter )
+void ota_handle( void * parameter )
 {
-  ArduinoOTA.handle();
-  delay(3500);
+  for (;;) {
+    ArduinoOTA.handle();
+    delay(3500);
+  }
 }
 #endif
 


### PR DESCRIPTION
The define for ESP32_RTOS must have a value for it to be picked up (at least in platformio). Fix the name of the defined rtos task function and ensure the task never returns (fixes brownout issue on ESP32).