### PR TITLE
Fixes to get RTOS option on ESP32 working and TelnetStream working

### DIFF
--- a/0TA_Template_Sketch/0TA_Template_Sketch.ino
+++ b/0TA_Template_Sketch/0TA_Template_Sketch.ino
@@ -1,7 +1,6 @@
-#include "OTA.h"
-unsigned long entry;
-
 // #define ESP32_RTOS  // Uncomment this line if you want to use the code with freertos (only works on the ESP32)
+
+#include "OTA.h"
 
 void setup() {
   Serial.begin(115200);

--- a/0TA_Template_Sketch/OTA.h
+++ b/0TA_Template_Sketch/OTA.h
@@ -9,16 +9,19 @@
 
 #include <WiFiUdp.h>
 #include <ArduinoOTA.h>
-#include <credentials.h>
+#include "credentials.h"
 
 const char* ssid = mySSID;
 const char* password = myPASSWORD;
 
 #if defined(ESP32_RTOS) && defined(ESP32)
-void taskOne( void * parameter )
+void ota_handle( void * parameter )
 {
-  ArduinoOTA.handle();
-  delay(3500);
+  while (true)    // to avoid: "E (4725) FreeRTOS: FreeRTOS Task "OTA_HANDLE" should not return, Aborting now!"
+  {
+    ArduinoOTA.handle();
+    delay(3500);
+  }
 }
 #endif
 

--- a/0TA_Template_Sketch/credentials.h
+++ b/0TA_Template_Sketch/credentials.h
@@ -1,0 +1,2 @@
+#define mySSID      "enter_your_wifi_network_name_here"
+#define myPASSWORD  "enter_your_wifi_network_password_here"

--- a/0TA_Template_Sketch_TelnetStream/0TA_Template_Sketch_TelnetStream.ino
+++ b/0TA_Template_Sketch_TelnetStream/0TA_Template_Sketch_TelnetStream.ino
@@ -1,6 +1,5 @@
-#include "OTA.h"
-
 // #define ESP32_RTOS  // Uncomment this line if you want to use the code with freertos (only works on the ESP32)
+#include "OTA.h"
 
 unsigned long entry;
 
@@ -12,6 +11,8 @@ void setup() {
 }
 
 void loop() {
+  TelnetStream.read();  // Seems including this line in the loop is the only way to get anything to display with TelnetStream
+  
   entry=micros();
   
   #ifndef ESP32_RTOS

--- a/0TA_Template_Sketch_TelnetStream/OTA.h
+++ b/0TA_Template_Sketch_TelnetStream/OTA.h
@@ -9,16 +9,19 @@
 #include <WiFiUdp.h>
 #include <ArduinoOTA.h>
 #include <TelnetStream.h>
-#include <credentials.h>
+#include "credentials.h"
 
 const char* ssid = mySSID;
 const char* password = myPASSWORD;
 
 #if defined(ESP32_RTOS) && defined(ESP32)
-void taskOne( void * parameter )
+void ota_handle( void * parameter )
 {
-  ArduinoOTA.handle();
-  delay(3500);
+  while (true)  // to avoid: "E (4725) FreeRTOS: FreeRTOS Task "OTA_HANDLE" should not return, Aborting now!"
+  {
+    ArduinoOTA.handle();
+    delay(3500);
+  }
 }
 #endif
 

--- a/0TA_Template_Sketch_TelnetStream/credentials.h
+++ b/0TA_Template_Sketch_TelnetStream/credentials.h
@@ -1,0 +1,2 @@
+#define mySSID      "your_network_name_here"
+#define myPASSWORD  "your_network_password_here"


### PR DESCRIPTION
Hi Andreas

Thanks again for all the videos. Hopefully this is a small payback. Quick summary:

- define moved above include so it can actually be referenced in the include
- task function name changed to be the same as in the task definition
- task code placed inside infinite loop to avoid return errors
- discovered the trick to getting TelnetStream working is to always read first (has to be in the loop too)
- added dummy credential files for "standalone'ness" and changed the include to local ("")

Since making the changes I've re-downloaded, and tested both examples several times using the 2 different methods of OTA.handle

Feel free to adjust to suit. About the TelnetStream read. I think this might be a bug in TelnetStream. The author may not have noticed though as their examples always read first anyway (for demonstration purposes).

I will try and contact them to let them know...